### PR TITLE
Active Bounty Refactor

### DIFF
--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModel.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModel.java
@@ -47,7 +47,10 @@ public class ContractModel {
     private Timestamp proposedAt;
 
     @Setter(AccessLevel.NONE)
-    private Timestamp acceptedAt;
+    private Timestamp activatedAt;
+    
+    @Setter(AccessLevel.NONE)
+    private Timestamp deactivatedAt;
 
     @Setter(AccessLevel.NONE)
     private Timestamp declinedAt;
@@ -81,8 +84,8 @@ public class ContractModel {
         state = newContractState;
         final Timestamp transitionTimestamp = new Timestamp(System.currentTimeMillis());
         switch (newContractState) {
-            case ACCEPTED:
-                acceptedAt = transitionTimestamp;
+            case ACTIVE:
+                activatedAt = transitionTimestamp;
                 break;
             case DECLINED:
                 declinedAt = transitionTimestamp;
@@ -99,6 +102,9 @@ public class ContractModel {
             case DISPUTED:
                 disputedAt = transitionTimestamp;
                 break;
+            case OPEN:
+            	deactivatedAt = transitionTimestamp;
+            	break;
             default:
                 throw new IllegalStateException(String.format("Error. Attempting to transition a contract to an invalid state. Contract Id: %s State: %s",
                         id,

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModel.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModel.java
@@ -2,6 +2,8 @@ package com.nicknathanjustin.streamercontracts.contracts;
 
 import com.nicknathanjustin.streamercontracts.donations.DonationModel;
 import com.nicknathanjustin.streamercontracts.users.UserModel;
+import com.nicknathanjustin.streamercontracts.votes.VoteModel;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -79,6 +81,9 @@ public class ContractModel {
 
     @OneToMany(mappedBy = "contract")
     private List<DonationModel> donations;
+    
+    @OneToMany(mappedBy = "contract")
+    private List<VoteModel> votes;
 
     public void setContractState(final ContractState newContractState) {
         state = newContractState;

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -25,7 +25,7 @@ public interface ContractModelRepository extends CrudRepository<ContractModel, U
     @Query("SELECT contractModel " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.settlesAt < :currentTimestamp " +
-           "AND contractModel.state = 'ACCEPTED' " +
+           "AND contractModel.state = 'ACTIVE' OR contractModel.state = 'OPEN' " +
            "ORDER BY contractModel.proposedAt DESC")
     Set<ContractModel> findAllSettleableContracts(@Param("currentTimestamp") Timestamp now);
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -1,6 +1,6 @@
 package com.nicknathanjustin.streamercontracts.contracts;
 
-import com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto;
+import com.nicknathanjustin.streamercontracts.contracts.dtos.Contract;
 import com.nicknathanjustin.streamercontracts.users.UserModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,48 +29,76 @@ public interface ContractModelRepository extends CrudRepository<ContractModel, U
            "ORDER BY contractModel.proposedAt DESC")
     Set<ContractModel> findAllSettleableContracts(@Param("currentTimestamp") Timestamp now);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "contractModel) " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.state = :state " +
            "AND contractModel.streamer.twitchUsername = :streamer " +
            "ORDER BY contractModel.proposedAt DESC")
-    Page<ContractDto> findAllContractsForStreamerAndState(@Param("streamer") String streamer, @Param("state") ContractState state, Pageable pageable);
+    Page<Contract> findAllPrivateContractsForStreamerAndState(@Param("streamer") String streamer, @Param("state") ContractState state, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "contractModel) " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.streamer.twitchUsername = :streamer " +
            "ORDER BY contractModel.proposedAt DESC")
-    Page<ContractDto> findAllContractsForStreamer(@Param("streamer") String streamer, Pageable pageable);
+    Page<Contract> findAllPrivateContractsForStreamer(@Param("streamer") String streamer, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "contractModel) " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.state = :state " +
            "ORDER BY contractModel.proposedAt DESC")
-    Page<ContractDto> findAllContractsForState(@Param("state") ContractState state, Pageable pageable);
+    Page<Contract> findAllPrivateContractsForState(@Param("state") ContractState state, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "contractModel) " +
            "FROM ContractModel contractModel  " +
            "ORDER BY contractModel.proposedAt DESC")
-    Page<ContractDto> findAllContracts(Pageable pageable);
+    Page<Contract> findAllPrivateContracts(Pageable pageable);
+    
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PublicContract(" +
+                "contractModel) " +
+           "FROM ContractModel contractModel " +
+           "WHERE contractModel.state = :state " +
+           "AND contractModel.streamer.twitchUsername = :streamer " +
+           "ORDER BY contractModel.proposedAt DESC")
+    Page<Contract> findAllPublicContractsForStreamerAndState(@Param("streamer") String streamer, @Param("state") ContractState state, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PublicContract(" +
+                "contractModel) " +
+           "FROM ContractModel contractModel " +
+           "WHERE contractModel.streamer.twitchUsername = :streamer " +
+           "ORDER BY contractModel.proposedAt DESC")
+    Page<Contract> findAllPublicContractsForStreamer(@Param("streamer") String streamer, Pageable pageable);
+
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PublicContract(" +
+                "contractModel) " +
+           "FROM ContractModel contractModel " +
+           "WHERE contractModel.state = :state " +
+           "ORDER BY contractModel.proposedAt DESC")
+    Page<Contract> findAllPublicContractsForState(@Param("state") ContractState state, Pageable pageable);
+
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PublicContract(" +
+                "contractModel) " +
+           "FROM ContractModel contractModel " +
+           "ORDER BY contractModel.proposedAt DESC")
+    Page<Contract> findAllPublicContracts(Pageable pageable);
+
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "donationModel.contract) " +
            "FROM DonationModel donationModel " +
            "WHERE donationModel.donator.twitchUsername = :donator " +
            "AND donationModel.contract.state = :state " +
            "ORDER BY donationModel.contract.proposedAt DESC")
-    Page<ContractDto> findAllContractsForDonatorAndState(@Param("donator") String donator, @Param("state") ContractState state, Pageable pageable);
+    Page<Contract> findAllContractsForDonatorAndState(@Param("donator") String donator, @Param("state") ContractState state, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto(" +
+    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "donationModel.contract) " +
            "FROM DonationModel donationModel " +
            "WHERE donationModel.donator.twitchUsername = :donator " +
            "ORDER BY donationModel.contract.proposedAt DESC")
-    Page<ContractDto> findAllContractsForDonator(@Param("donator") String donator, Pageable pageable);
+    Page<Contract> findAllContractsForDonator(@Param("donator") String donator, Pageable pageable);
 
     @Query("SELECT SUM(d.donationAmount) " +
            "FROM DonationModel d " +

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -88,17 +88,17 @@ public interface ContractModelRepository extends CrudRepository<ContractModel, U
     @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "donationModel.contract) " +
            "FROM DonationModel donationModel " +
-           "WHERE donationModel.donator.twitchUsername = :donator " +
+           "WHERE donationModel.donor.twitchUsername = :donor " +
            "AND donationModel.contract.state = :state " +
            "ORDER BY donationModel.contract.proposedAt DESC")
-    Page<Contract> findAllContractsForDonatorAndState(@Param("donator") String donator, @Param("state") ContractState state, Pageable pageable);
+    Page<Contract> findAllContractsForDonorAndState(@Param("donor") String donor, @Param("state") ContractState state, Pageable pageable);
 
     @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
                 "donationModel.contract) " +
            "FROM DonationModel donationModel " +
-           "WHERE donationModel.donator.twitchUsername = :donator " +
+           "WHERE donationModel.donor.twitchUsername = :donor " +
            "ORDER BY donationModel.contract.proposedAt DESC")
-    Page<Contract> findAllContractsForDonator(@Param("donator") String donator, Pageable pageable);
+    Page<Contract> findAllContractsForDonor(@Param("donor") String donor, Pageable pageable);
 
     @Query("SELECT SUM(d.donationAmount) " +
            "FROM DonationModel d " +

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -11,14 +11,17 @@ import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 @Repository
 public interface ContractModelRepository extends CrudRepository<ContractModel, UUID> {
+	
+	List<ContractModel> findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState state, UserModel streamer);
 
     long countByStateAndStreamer(ContractState state, UserModel streamer);
-
+    
     @Query("SELECT contractModel " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.settlesAt < :currentTimestamp " +

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -44,19 +44,6 @@ public interface ContractModelRepository extends CrudRepository<ContractModel, U
            "ORDER BY contractModel.proposedAt DESC")
     Page<Contract> findAllPrivateContractsForStreamer(@Param("streamer") String streamer, Pageable pageable);
 
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
-                "contractModel) " +
-           "FROM ContractModel contractModel " +
-           "WHERE contractModel.state = :state " +
-           "ORDER BY contractModel.proposedAt DESC")
-    Page<Contract> findAllPrivateContractsForState(@Param("state") ContractState state, Pageable pageable);
-
-    @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PrivateContract(" +
-                "contractModel) " +
-           "FROM ContractModel contractModel  " +
-           "ORDER BY contractModel.proposedAt DESC")
-    Page<Contract> findAllPrivateContracts(Pageable pageable);
-    
     @Query("SELECT new com.nicknathanjustin.streamercontracts.contracts.dtos.PublicContract(" +
                 "contractModel) " +
            "FROM ContractModel contractModel " +

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractModelRepository.java
@@ -18,10 +18,10 @@ import java.util.UUID;
 @Repository
 public interface ContractModelRepository extends CrudRepository<ContractModel, UUID> {
 	
-	List<ContractModel> findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState state, UserModel streamer);
+    List<ContractModel> findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState state, UserModel streamer);
 
     long countByStateAndStreamer(ContractState state, UserModel streamer);
-    
+ 
     @Query("SELECT contractModel " +
            "FROM ContractModel contractModel " +
            "WHERE contractModel.settlesAt < :currentTimestamp " +

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -128,4 +129,11 @@ public interface ContractService {
      * @return the total amount of money the streamer has earned.
      */
     BigDecimal getMoneyForStreamerAndState(UserModel streamer, ContractState state);
+    
+    /**
+     * Activates the contract.
+     *
+     * @param contractModel The contract to activate.
+     */
+    void activeContract(ContractModel contractModel);
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -135,5 +135,5 @@ public interface ContractService {
      *
      * @param contractModel The contract to activate.
      */
-    void activeContract(ContractModel contractModel);
+    void activateContract(ContractModel contractModel);
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -49,7 +49,7 @@ public interface ContractService {
     void setContractState(ContractModel contractModel, ContractState newContractState);
 
     /**
-     * Settles payments for a contract by releasing each donation to either the donator or the streamer.
+     * Settles payments for a contract by releasing each donation to either the donor or the streamer.
      *
      * @param contractModel the contract to settle payment for.
      */
@@ -99,22 +99,22 @@ public interface ContractService {
      * Gets all contracts where the contract contains a donation from the given proposer
      * and is in the given state.
      *
-     * @param donator The user to retrieve contracts by.
+     * @param donor The user to retrieve contracts by.
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
      * @return all contracts where the contract contains a donation from the given proposer
      * and is in the given state.
      */
-    Page<Contract> getContractsForDonatorAndState(UserModel donator, ContractState state, Pageable pageable);
+    Page<Contract> getContractsForDonorAndState(UserModel donor, ContractState state, Pageable pageable);
 
     /**
      * Gets all contracts where the contract contains a donation from the given proposer.
      *
-     * @param donator The user to retrieve contracts by.
+     * @param donor The user to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<Contract> getContractsForDonator(UserModel donator, Pageable pageable);
+    Page<Contract> getContractsForDonor(UserModel donor, Pageable pageable);
 
     /**
      * Counts the contracts given the state and the streamer.

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -61,39 +61,37 @@ public interface ContractService {
      * @param streamer The user to retrieve contracts by.
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param isLoggedIn flag that indicates if the user is logged in.
+     * @param username The username of the user that made the request.
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<Contract> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable, boolean isLoggedIn);
+    Page<Contract> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable, String username);
 
     /**
      * Gets all contracts for the given user.
      *
      * @param streamer The user to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param isLoggedIn flag that indicates if the user is logged in.
+     * @param username The username of the user that made the request.
      * @return a set of all contracts for the given user.
      */
-    Page<Contract> getContractsForStreamer(UserModel streamer, Pageable pageable, boolean isLoggedIn);
+    Page<Contract> getContractsForStreamer(UserModel streamer, Pageable pageable, String username);
 
     /**
      * Gets all contracts in the given state.
      *
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<Contract> getContractsForState(ContractState state, Pageable pageable, boolean isLoggedIn);
+    Page<Contract> getContractsForState(ContractState state, Pageable pageable);
 
     /**
      * Gets all contracts.
      *
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return all of the contracts.
      */
-    Page<Contract> getAllContracts(Pageable pageable, boolean isLoggedIn);
+    Page<Contract> getAllContracts(Pageable pageable);
 
     /**
      * Gets all contracts where the contract contains a donation from the given proposer

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -1,6 +1,6 @@
 package com.nicknathanjustin.streamercontracts.contracts;
 
-import com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto;
+import com.nicknathanjustin.streamercontracts.contracts.dtos.Contract;
 import com.nicknathanjustin.streamercontracts.users.UserModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -61,35 +61,39 @@ public interface ContractService {
      * @param streamer The user to retrieve contracts by.
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
+     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<ContractDto> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable);
+    Page<Contract> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable, boolean isLoggedIn);
 
     /**
      * Gets all contracts for the given user.
      *
      * @param streamer The user to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
+     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return a set of all contracts for the given user.
      */
-    Page<ContractDto> getContractsForStreamer(UserModel streamer, Pageable pageable);
+    Page<Contract> getContractsForStreamer(UserModel streamer, Pageable pageable, boolean isLoggedIn);
 
     /**
      * Gets all contracts in the given state.
      *
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
+     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<ContractDto> getContractsForState(ContractState state, Pageable pageable);
+    Page<Contract> getContractsForState(ContractState state, Pageable pageable, boolean isLoggedIn);
 
     /**
      * Gets all contracts.
      *
      * @param pageable identifies the page number and pagesize to retrieve
+     * @param isLoggedIn flag that indicates if the user is logged in.
      * @return all of the contracts.
      */
-    Page<ContractDto> getAllContracts(Pageable pageable);
+    Page<Contract> getAllContracts(Pageable pageable, boolean isLoggedIn);
 
     /**
      * Gets all contracts where the contract contains a donation from the given proposer
@@ -101,7 +105,7 @@ public interface ContractService {
      * @return all contracts where the contract contains a donation from the given proposer
      * and is in the given state.
      */
-    Page<ContractDto> getContractsForDonatorAndState(UserModel donator, ContractState state, Pageable pageable);
+    Page<Contract> getContractsForDonatorAndState(UserModel donator, ContractState state, Pageable pageable);
 
     /**
      * Gets all contracts where the contract contains a donation from the given proposer.
@@ -110,7 +114,7 @@ public interface ContractService {
      * @param pageable identifies the page number and pagesize to retrieve
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<ContractDto> getContractsForDonator(UserModel donator, Pageable pageable);
+    Page<Contract> getContractsForDonator(UserModel donator, Pageable pageable);
 
     /**
      * Counts the contracts given the state and the streamer.

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -137,7 +137,7 @@ public class ContractServiceImpl implements ContractService {
         List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
         if (activeContracts.size() > MAX_ACTIVE_CONTRACTS) {
             throw new IllegalStateException(String.format("Cannot have more than %s active contracts. Streamer Id: %s", MAX_ACTIVE_CONTRACTS, contractModel.getStreamer().getId()));
-        } else if (activeContracts.size() + 1 < MAX_ACTIVE_CONTRACTS) {
+        } else if (activeContracts.size() < MAX_ACTIVE_CONTRACTS) {
             this.setContractState(contractModel, ContractState.ACTIVE);
         } else {
             // We will employ a LIFO policy for active contracts. The least recently active contract

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -1,15 +1,13 @@
 package com.nicknathanjustin.streamercontracts.contracts;
 
 import com.google.common.collect.ImmutableList;
-import com.nicknathanjustin.streamercontracts.contracts.dtos.ContractDto;
+import com.nicknathanjustin.streamercontracts.contracts.dtos.Contract;
 import com.nicknathanjustin.streamercontracts.donations.DonationService;
 import com.nicknathanjustin.streamercontracts.users.UserModel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 
 import java.math.BigDecimal;
@@ -90,35 +88,50 @@ public class ContractServiceImpl implements ContractService {
     }
 
     @Override
-    public Page<ContractDto> getContractsForStreamerAndState(@NonNull final UserModel user, @NonNull final ContractState state, @NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContractsForStreamerAndState(
-                user.getTwitchUsername(),
-                state,
-                pageable);
+    public Page<Contract> getContractsForStreamerAndState(
+            @NonNull final UserModel user, 
+            @NonNull final ContractState state, 
+            @NonNull final Pageable pageable, 
+            final boolean isLoggedIn) {
+        return isLoggedIn ? 
+                contractModelRepository.findAllPrivateContractsForStreamerAndState(user.getTwitchUsername(), state, pageable) :
+                contractModelRepository.findAllPublicContractsForStreamerAndState(user.getTwitchUsername(), state, pageable);
     }
 
     @Override
-    public Page<ContractDto> getContractsForStreamer(@NonNull final UserModel user, @NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContractsForStreamer(user.getTwitchUsername(), pageable);
+    public Page<Contract> getContractsForStreamer(
+            @NonNull final UserModel user, 
+            @NonNull final Pageable pageable,
+            final boolean isLoggedIn) {
+        return isLoggedIn ? 
+                contractModelRepository.findAllPrivateContractsForStreamer(user.getTwitchUsername(), pageable) :
+                contractModelRepository.findAllPublicContractsForStreamer(user.getTwitchUsername(), pageable);
     }
 
     @Override
-    public Page<ContractDto> getContractsForState(@NonNull final ContractState state, @NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContractsForState(state, pageable);
+    public Page<Contract> getContractsForState(
+            @NonNull final ContractState state,
+            @NonNull final Pageable pageable,
+            final boolean isLoggedIn) {
+        return isLoggedIn ? 
+                contractModelRepository.findAllPrivateContractsForState(state, pageable) :
+                contractModelRepository.findAllPublicContractsForState(state, pageable);
     }
 
     @Override
-    public Page<ContractDto> getAllContracts(@NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContracts(pageable);
+    public Page<Contract> getAllContracts(@NonNull final Pageable pageable, final boolean isLoggedIn) {
+        return isLoggedIn ? 
+                contractModelRepository.findAllPrivateContracts(pageable) :
+                contractModelRepository.findAllPublicContracts(pageable);
     }
 
     @Override
-    public Page<ContractDto> getContractsForDonatorAndState(@NonNull final UserModel donator, @NonNull final ContractState state, @NonNull final Pageable pageable) {
+    public Page<Contract> getContractsForDonatorAndState(@NonNull final UserModel donator, @NonNull final ContractState state, @NonNull final Pageable pageable) {
         return contractModelRepository.findAllContractsForDonatorAndState(donator.getTwitchUsername(), state, pageable);
     }
 
     @Override
-    public Page<ContractDto> getContractsForDonator(@NonNull final UserModel donator, @NonNull final Pageable pageable) {
+    public Page<Contract> getContractsForDonator(@NonNull final UserModel donator, @NonNull final Pageable pageable) {
         return contractModelRepository.findAllContractsForDonator(donator.getTwitchUsername(), pageable);
     }
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -92,8 +92,13 @@ public class ContractServiceImpl implements ContractService {
             @NonNull final UserModel user, 
             @NonNull final ContractState state, 
             @NonNull final Pageable pageable, 
-            final boolean isLoggedIn) {
-        return isLoggedIn ? 
+            @Nullable final String username) {
+        boolean requestedByStreamer = false;
+        if (username != null) {
+            requestedByStreamer = username.equals(user.getTwitchUsername());
+        }
+
+        return requestedByStreamer ?
                 contractModelRepository.findAllPrivateContractsForStreamerAndState(user.getTwitchUsername(), state, pageable) :
                 contractModelRepository.findAllPublicContractsForStreamerAndState(user.getTwitchUsername(), state, pageable);
     }
@@ -102,8 +107,13 @@ public class ContractServiceImpl implements ContractService {
     public Page<Contract> getContractsForStreamer(
             @NonNull final UserModel user, 
             @NonNull final Pageable pageable,
-            final boolean isLoggedIn) {
-        return isLoggedIn ? 
+            @Nullable final String username) {
+        boolean requestedByStreamer = false;
+        if (username != null) {
+            requestedByStreamer = username.equals(user.getTwitchUsername());
+        }
+
+        return requestedByStreamer ?
                 contractModelRepository.findAllPrivateContractsForStreamer(user.getTwitchUsername(), pageable) :
                 contractModelRepository.findAllPublicContractsForStreamer(user.getTwitchUsername(), pageable);
     }
@@ -111,18 +121,13 @@ public class ContractServiceImpl implements ContractService {
     @Override
     public Page<Contract> getContractsForState(
             @NonNull final ContractState state,
-            @NonNull final Pageable pageable,
-            final boolean isLoggedIn) {
-        return isLoggedIn ? 
-                contractModelRepository.findAllPrivateContractsForState(state, pageable) :
-                contractModelRepository.findAllPublicContractsForState(state, pageable);
+            @NonNull final Pageable pageable) {
+        return contractModelRepository.findAllPublicContractsForState(state, pageable);
     }
 
     @Override
-    public Page<Contract> getAllContracts(@NonNull final Pageable pageable, final boolean isLoggedIn) {
-        return isLoggedIn ? 
-                contractModelRepository.findAllPrivateContracts(pageable) :
-                contractModelRepository.findAllPublicContracts(pageable);
+    public Page<Contract> getAllContracts(@NonNull final Pageable pageable) {
+        return contractModelRepository.findAllPublicContracts(pageable);
     }
 
     @Override

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -133,7 +133,7 @@ public class ContractServiceImpl implements ContractService {
     }
     
     @Override
-    public void activeContract(@NonNull final ContractModel contractModel) {
+    public void activateContract(@NonNull final ContractModel contractModel) {
         List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
         if (activeContracts.size() > MAX_ACTIVE_CONTRACTS) {
             throw new IllegalStateException(String.format("Cannot have more than %s active contracts. Streamer Id: %s", MAX_ACTIVE_CONTRACTS, contractModel.getStreamer().getId()));

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -147,7 +147,7 @@ public class ContractServiceImpl implements ContractService {
     
     @Override
     public void activateContract(@NonNull final ContractModel contractModel) {
-        List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
+        final List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
         if (activeContracts.size() > MAX_ACTIVE_CONTRACTS) {
             throw new IllegalStateException(String.format("Cannot have more than %s active contracts. Streamer Id: %s", MAX_ACTIVE_CONTRACTS, contractModel.getStreamer().getId()));
         } else if (activeContracts.size() < MAX_ACTIVE_CONTRACTS) {
@@ -155,7 +155,7 @@ public class ContractServiceImpl implements ContractService {
         } else {
             // We will employ a LIFO policy for active contracts. The least recently active contract
             // will be deactivated.
-            ContractModel oldestActiveContract = activeContracts.get(activeContracts.size() - 1);
+            final ContractModel oldestActiveContract = activeContracts.get(activeContracts.size() - 1);
             this.setContractState(oldestActiveContract, ContractState.OPEN);
             this.setContractState(contractModel, ContractState.ACTIVE);
         }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -134,17 +134,17 @@ public class ContractServiceImpl implements ContractService {
     
     @Override
     public void activeContract(@NonNull final ContractModel contractModel) {
-    	List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
+        List<ContractModel> activeContracts = contractModelRepository.findAllByStateAndStreamerOrderByActivatedAtDesc(ContractState.ACTIVE, contractModel.getStreamer());
         if (activeContracts.size() > MAX_ACTIVE_CONTRACTS) {
-        	throw new IllegalStateException(String.format("Cannot have more than %s active contracts. Streamer Id: %s", MAX_ACTIVE_CONTRACTS, contractModel.getStreamer().getId()));
+            throw new IllegalStateException(String.format("Cannot have more than %s active contracts. Streamer Id: %s", MAX_ACTIVE_CONTRACTS, contractModel.getStreamer().getId()));
         } else if (activeContracts.size() + 1 < MAX_ACTIVE_CONTRACTS) {
-        	this.setContractState(contractModel, ContractState.ACTIVE);
+            this.setContractState(contractModel, ContractState.ACTIVE);
         } else {
-        	// We will employ a LIFO policy for active contracts. The least recently active contract
-        	// will be deactivated.
-        	ContractModel oldestActiveContract = activeContracts.get(activeContracts.size() - 1);
-        	this.setContractState(oldestActiveContract, ContractState.OPEN);
-        	this.setContractState(contractModel, ContractState.ACTIVE);
+            // We will employ a LIFO policy for active contracts. The least recently active contract
+            // will be deactivated.
+            ContractModel oldestActiveContract = activeContracts.get(activeContracts.size() - 1);
+            this.setContractState(oldestActiveContract, ContractState.OPEN);
+            this.setContractState(contractModel, ContractState.ACTIVE);
         }
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -126,13 +126,13 @@ public class ContractServiceImpl implements ContractService {
     }
 
     @Override
-    public Page<Contract> getContractsForDonatorAndState(@NonNull final UserModel donator, @NonNull final ContractState state, @NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContractsForDonatorAndState(donator.getTwitchUsername(), state, pageable);
+    public Page<Contract> getContractsForDonorAndState(@NonNull final UserModel donor, @NonNull final ContractState state, @NonNull final Pageable pageable) {
+        return contractModelRepository.findAllContractsForDonorAndState(donor.getTwitchUsername(), state, pageable);
     }
 
     @Override
-    public Page<Contract> getContractsForDonator(@NonNull final UserModel donator, @NonNull final Pageable pageable) {
-        return contractModelRepository.findAllContractsForDonator(donator.getTwitchUsername(), pageable);
+    public Page<Contract> getContractsForDonor(@NonNull final UserModel donor, @NonNull final Pageable pageable) {
+        return contractModelRepository.findAllContractsForDonor(donor.getTwitchUsername(), pageable);
     }
 
     @Override

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractState.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractState.java
@@ -2,7 +2,7 @@ package com.nicknathanjustin.streamercontracts.contracts;
 
 public enum ContractState {
     OPEN,
-    ACCEPTED,
+    ACTIVE,
     DECLINED,
     EXPIRED,
     COMPLETED,

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -84,19 +84,15 @@ public class ContractsApiController {
         final Pageable pageable = PageRequest.of(page, pageSize);
         Page<Contract> contracts = null;
         final UserModel streamer = username != null ? userService.getUser(username).orElse(null) : null;
-        boolean isLoggedIn = false;
-        if (streamer != null && user != null) {
-            isLoggedIn = user.getTwitchUsername().equals(streamer.getTwitchUsername());
-        }
 
         if (streamer != null && state != null) {
-            contracts = contractService.getContractsForStreamerAndState(streamer, state, pageable, isLoggedIn);
+            contracts = contractService.getContractsForStreamerAndState(streamer, state, pageable, user.getTwitchUsername());
         } else if (streamer != null) {
-            contracts = contractService.getContractsForStreamer(streamer, pageable, isLoggedIn);
+            contracts = contractService.getContractsForStreamer(streamer, pageable, user.getTwitchUsername());
         } else if (state != null) {
-            contracts = contractService.getContractsForState(state, pageable, isLoggedIn);
+            contracts = contractService.getContractsForState(state, pageable);
         } else {
-            contracts = contractService.getAllContracts(pageable, isLoggedIn);
+            contracts = contractService.getAllContracts(pageable);
         }
 
         return ResponseEntity.ok(contracts);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -25,6 +25,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -33,7 +35,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Slf4j
 public class ContractsApiController {
-
+	
     @NonNull private final ContractService contractService;
     @NonNull private final SecurityService SecurityService;
     @NonNull private final UserService userService;
@@ -115,8 +117,8 @@ public class ContractsApiController {
         return ResponseEntity.ok(contracts);
     }
 
-    @RequestMapping(path = "accept", method = RequestMethod.PUT)
-    public ResponseEntity acceptContract(
+    @RequestMapping(path = "activate", method = RequestMethod.PUT)
+    public ResponseEntity activateContract(
             @NonNull final HttpServletRequest httpServletRequest,
             @RequestBody @NonNull final ContractStateRequest contractStateRequest) {
         if (SecurityService.isAnonymousRequest(httpServletRequest)) {
@@ -132,8 +134,8 @@ public class ContractsApiController {
         if (!contractModel.getState().equals(ContractState.OPEN)) {
             throw new IllegalStateException(String.format("Cannot accept a contract that is not OPEN. Contract Id: %s Contract State: %s", contractId, contractModel.getState().name()));
         }
-
-        contractService.setContractState(contractModel, ContractState.ACCEPTED);
+        
+        contractService.activeContract(contractModel);
         return new ResponseEntity(HttpStatus.OK);
     }
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -116,9 +116,9 @@ public class ContractsApiController {
         final Pageable pageable = PageRequest.of(page, pageSize);
         Page<Contract> contracts = null;
         if (state != null) {
-            contracts = contractService.getContractsForDonatorAndState(donor, state, pageable);
+            contracts = contractService.getContractsForDonorAndState(donor, state, pageable);
         } else {
-            contracts = contractService.getContractsForDonator(donor, pageable);
+            contracts = contractService.getContractsForDonor(donor, pageable);
         }
 
         return ResponseEntity.ok(contracts);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -135,7 +135,7 @@ public class ContractsApiController {
             throw new IllegalStateException(String.format("Cannot accept a contract that is not OPEN. Contract Id: %s Contract State: %s", contractId, contractModel.getState().name()));
         }
  
-        contractService.activeContract(contractModel);
+        contractService.activateContract(contractModel);
         return new ResponseEntity(HttpStatus.OK);
     }
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Slf4j
 public class ContractsApiController {
-	
+
     @NonNull private final ContractService contractService;
     @NonNull private final SecurityService SecurityService;
     @NonNull private final UserService userService;
@@ -134,7 +134,7 @@ public class ContractsApiController {
         if (!contractModel.getState().equals(ContractState.OPEN)) {
             throw new IllegalStateException(String.format("Cannot accept a contract that is not OPEN. Contract Id: %s Contract State: %s", contractId, contractModel.getState().name()));
         }
-        
+ 
         contractService.activeContract(contractModel);
         return new ResponseEntity(HttpStatus.OK);
     }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/Contract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/Contract.java
@@ -1,20 +1,22 @@
 package com.nicknathanjustin.streamercontracts.contracts.dtos;
 
-import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
-import com.nicknathanjustin.streamercontracts.contracts.ContractState;
-import com.nicknathanjustin.streamercontracts.donations.DonationModel;
-import com.nicknathanjustin.streamercontracts.donations.dtos.DonationDto;
-import lombok.Data;
-import lombok.NonNull;
-
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
+import com.nicknathanjustin.streamercontracts.contracts.ContractState;
+import com.nicknathanjustin.streamercontracts.donations.DonationModel;
+import com.nicknathanjustin.streamercontracts.donations.dtos.DonationDto;
+
+import lombok.Data;
+import lombok.NonNull;
+
 @Data
-public class ContractDto {
+public abstract class Contract {
+
     private UUID contractId;
     private ContractState state;
     private BigDecimal contractAmount;
@@ -33,8 +35,8 @@ public class ContractDto {
     private String streamerName;
     private String proposerName;
     private List<DonationDto> donations;
-
-    public ContractDto(@NonNull final ContractModel contract) {
+    
+    public Contract(@NonNull final ContractModel contract) {
         contractId = contract.getId();
         state = contract.getState();
         description = contract.getDescription();

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/ContractDto.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/ContractDto.java
@@ -22,7 +22,8 @@ public class ContractDto {
     private boolean isCommunity;
     private String game;
     private Timestamp proposedAt;
-    private Timestamp acceptedAt;
+    private Timestamp activatedAt;
+    private Timestamp deactivatedAt;
     private Timestamp declinedAt;
     private Timestamp settlesAt;
     private Timestamp expiredAt;
@@ -40,7 +41,8 @@ public class ContractDto {
         isCommunity = contract.isCommunityContract();
         game = contract.getGame();
         proposedAt = contract.getProposedAt();
-        acceptedAt = contract.getAcceptedAt();
+        activatedAt = contract.getActivatedAt();
+        deactivatedAt = contract.getDeactivatedAt();
         declinedAt = contract.getDeclinedAt();
         settlesAt = contract.getSettlesAt();
         expiredAt = contract.getExpiredAt();

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
@@ -1,0 +1,23 @@
+package com.nicknathanjustin.streamercontracts.contracts.dtos;
+
+import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
+import com.nicknathanjustin.streamercontracts.votes.VoteModel;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class PrivateContract extends Contract {
+
+    private boolean userHasVoted;
+    
+    public PrivateContract(@NonNull final ContractModel contract) {
+        super(contract);
+        this.userHasVoted = false;
+        for (VoteModel vote : contract.getVotes()) {
+            if (vote.getVoter().getTwitchUsername().equals(contract.getStreamer().getTwitchUsername())) {
+                this.userHasVoted = true;
+            }
+        }
+    }
+}

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
@@ -6,6 +6,8 @@ import com.nicknathanjustin.streamercontracts.votes.VoteModel;
 import lombok.Data;
 import lombok.NonNull;
 
+import java.util.stream.Stream;
+
 @Data
 public class PrivateContract extends Contract {
 
@@ -13,11 +15,7 @@ public class PrivateContract extends Contract {
     
     public PrivateContract(@NonNull final ContractModel contract) {
         super(contract);
-        this.userHasVoted = false;
-        for (VoteModel vote : contract.getVotes()) {
-            if (vote.getVoter().getTwitchUsername().equals(contract.getStreamer().getTwitchUsername())) {
-                this.userHasVoted = true;
-            }
-        }
+        Stream<VoteModel> userVotes = contract.getVotes().stream().filter(voteModel -> voteModel.getVoter().getTwitchUsername().equals(contract.getStreamer().getTwitchUsername()));
+        this.userHasVoted = userVotes.count() > 0;
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PublicContract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PublicContract.java
@@ -1,0 +1,14 @@
+package com.nicknathanjustin.streamercontracts.contracts.dtos;
+
+import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
+
+import lombok.Value;
+
+@Value
+public class PublicContract extends Contract {
+
+    public PublicContract(ContractModel contract) {
+        super(contract);
+    }
+
+}

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/donations/DonationModel.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/donations/DonationModel.java
@@ -37,7 +37,7 @@ public class DonationModel {
     private ContractModel contract;
 
     @OneToOne
-    private UserModel donator;
+    private UserModel donor;
 
     private BigDecimal donationAmount;
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/donations/DonationServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/donations/DonationServiceImpl.java
@@ -27,7 +27,7 @@ public class DonationServiceImpl implements  DonationService{
             @NonNull final String paypalAuthorizationId) {
         donationModelRepository.save(DonationModel.builder()
                 .contract(contractModel)
-                .donator(donator)
+                .donor(donator)
                 .createdAt(contractTimestamp)
                 .donationAmount(donationAmount)
                 .paypalPaymentId(paypalPaymentId)

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UsersApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UsersApiController.java
@@ -42,7 +42,7 @@ public class UsersApiController {
         final UserModel userModel = userService.getUserModelFromRequest(httpServletRequest);
         final TwitchUser twitchUser = userService.getTwitchUserFromRequest(httpServletRequest);
         final long openContracts = contractService.countByStateAndStreamer(ContractState.OPEN, userModel);
-        final long acceptedContracts = contractService.countByStateAndStreamer(ContractState.ACCEPTED, userModel);
+        final long activeContracts = contractService.countByStateAndStreamer(ContractState.ACTIVE, userModel);
         final long declinedContracts = contractService.countByStateAndStreamer(ContractState.DECLINED, userModel);
         final long expiredContracts = contractService.countByStateAndStreamer(ContractState.EXPIRED, userModel);
         final long completedContracts = contractService.countByStateAndStreamer(ContractState.COMPLETED, userModel);
@@ -53,7 +53,7 @@ public class UsersApiController {
                 twitchUser,
                 userModel,
                 openContracts,
-                acceptedContracts,
+                activeContracts,
                 declinedContracts,
                 expiredContracts,
                 completedContracts,

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
@@ -22,9 +22,6 @@ public class VoteServiceImpl implements VoteService{
     public void recordVote(@NonNull final UserModel voter,
                            @NonNull final ContractModel contractModel,
                            final boolean flaggedCompleted) {
-    	if (isContractPastSettleTimestamp(contractModel)) {
-            throw new IllegalStateException(String.format("Cannot vote on a contract that is past the settlement timestamp. Contract Id: %s Settles At: %s", contractModel.getId(), contractModel.getSettlesAt().toString()));
-        }
         assertContractIsSettleable(contractModel);
         assertUserCanVoteOnContract(voter, contractModel);
 
@@ -115,6 +112,10 @@ public class VoteServiceImpl implements VoteService{
     }
 
     private void assertUserCanVoteOnContract(@NonNull final UserModel voter, @NonNull final ContractModel contractModel) {
+        if (isContractPastSettleTimestamp(contractModel)) {
+            throw new IllegalStateException(String.format("Cannot vote on a contract that is past the settlement timestamp. Contract Id: %s Settles At: %s", contractModel.getId(), contractModel.getSettlesAt().toString()));
+        }
+
         final UUID contractId = contractModel.getId();
 
         final UUID proposerId = contractModel.getProposer().getId();

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
@@ -84,7 +84,7 @@ public class VoteServiceImpl implements VoteService{
                     streamerVote.isViewerFlaggedComplete());
             voteOutcome = ContractState.COMPLETED;
         } else {
-        	// TODO: Implement community voting logic.
+            // TODO: Implement community voting logic.
             log.info("Disputed outcome detected when completing contract: {}", contractId);
         }
         

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/votes/VoteServiceImpl.java
@@ -68,7 +68,6 @@ public class VoteServiceImpl implements VoteService{
             log.info("Streamer has marked contract: {} as failed", contractId);
             voteOutcome = ContractState.FAILED;
         } else if(proposerVote == null && streamerVote == null) {
-            // If there are no votes on the contract, we will expire the contract.
             log.info("Neither Streamer nor Proposer voted on contract: {}. contractModel.getState(): {}",
                     contractId,
                     contractModel.getState());

--- a/dev_ops/sql/Tables/CreateContractDonations.sql
+++ b/dev_ops/sql/Tables/CreateContractDonations.sql
@@ -1,7 +1,7 @@
 CREATE TABLE contract_donations (
     id UUID PRIMARY KEY,
 	contract_id UUID REFERENCES contracts (id),
-	donator_id UUID REFERENCES users (id),
+	donor_id UUID REFERENCES users (id),
 	donation_amount MONEY CONSTRAINT positive_donation CHECK (donation_amount > 0::money) NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	paypal_payment_id VARCHAR(128) NOT NULL,

--- a/dev_ops/sql/Tables/CreateContracts.sql
+++ b/dev_ops/sql/Tables/CreateContracts.sql
@@ -5,7 +5,8 @@ CREATE TABLE contracts (
 	game VARCHAR(128) NULL,
 	description TEXT NOT NULL,
 	proposed_at TIMESTAMP NOT NULL,
-	accepted_at TIMESTAMP NULL,
+	activated_at TIMESTAMP NULL,
+	deactivated_at TIMESTAMP NULL,
 	declined_at TIMESTAMP NULL,
 	settles_at TIMESTAMP NOT NULL,
 	expired_at TIMESTAMP NULL,
@@ -16,10 +17,7 @@ CREATE TABLE contracts (
 	state SMALLINT NOT NULL,
 	dev_note TEXT NULL,
 	CONSTRAINT valid_timestamps CHECK (
-	    proposed_at < accepted_at AND -- if the contract is accepted, it must be accepted after its proposed
+	    proposed_at < activated_at AND -- if the contract is activated, it must be activated after its proposed
 		proposed_at < declined_at AND -- if the contract is declined, it must be declined after its proposed
-		proposed_at < expired_at AND -- if the contract is expired, it must be expired after its proposed
-		accepted_at < completed_at AND -- if the contract is completed, it must be completed after its accepted
-		accepted_at < failed_at AND -- if the contract is failed, it must be completed after its accepted
-		accepted_at < disputed_at) -- if the contract is disputed, it must be completed after its accepted
+		proposed_at < expired_at) -- if the contract is expired, it must be expired after its proposed
 );

--- a/dev_ops/sql/dev_scripts/CreateDummyContracts.sql
+++ b/dev_ops/sql/dev_scripts/CreateDummyContracts.sql
@@ -37,7 +37,7 @@ BEGIN
     FOR i in 1..numContracts LOOP
 	    random_user1 := (select id from users ORDER BY random() LIMIT 1);
 		random_user2 := (select id from users WHERE id != random_user1 ORDER BY random() LIMIT 1);
-		INSERT INTO contracts VALUES (uuid_generate_v1(), random_user1, random_user2, games[floor(random() * ((array_length(games, 1))-1+1) + 1)], descriptions[floor(random() * ((array_length(descriptions, 1))-1+1) + 1)], NOW(), NULL, NULL, NOW() + interval '3' day, NULL, NULL, NULL, NULL, false, 0, NULL);
+		INSERT INTO contracts VALUES (uuid_generate_v1(), random_user1, random_user2, games[floor(random() * ((array_length(games, 1))-1+1) + 1)], descriptions[floor(random() * ((array_length(descriptions, 1))-1+1) + 1)], NOW(), NULL, NULL, NULL, NOW() + interval '3' day, NULL, NULL, NULL, NULL, false, 0, NULL);
     END LOOP;
 END;
 

--- a/web/src/app/BountyState.js
+++ b/web/src/app/BountyState.js
@@ -1,5 +1,5 @@
 export const OPEN = 'OPEN';
-export const ACCEPTED = 'ACCEPTED';
+export const ACTIVE = 'ACTIVE';
 export const DECLINED = 'DECLINED';
 export const EXPIRED = 'EXPIRED';
 export const COMPLETED = 'COMPLETED';

--- a/web/src/app/profile/BountyDetails/BountyDetails.js
+++ b/web/src/app/profile/BountyDetails/BountyDetails.js
@@ -4,7 +4,7 @@ import {
   Glyphicon
 } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import { OPEN, ACCEPTED, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
+import { OPEN, ACTIVE, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
 import styles from './BountyDetails.scss';
 
 class BountyDetails extends Component {
@@ -91,7 +91,7 @@ class BountyDetails extends Component {
       return this.getDeclinedIcon();
     } else if (curBounty.state === EXPIRED || curBounty.state === FAILED) {
       return this.getFailedIcon();
-    } else if (curBounty.state === ACCEPTED && (this.props.isStreamer || this.props.isDonor)) {
+    } else if (curBounty.state === ACTIVE && (this.props.isStreamer || this.props.isDonor)) {
       return this.getAcceptButtons();
     } else if (curBounty.state === OPEN && this.props.isStreamer) {
       return this.getOpenButtons();

--- a/web/src/app/profile/DonationsComponent/DonationsComponent.js
+++ b/web/src/app/profile/DonationsComponent/DonationsComponent.js
@@ -6,7 +6,7 @@ import BootstrapTable from 'react-bootstrap-table-next';
 import BountyDetails from '../BountyDetails/BountyDetails';
 import paginationFactory from 'react-bootstrap-table2-paginator';
 import cx from 'classnames';
-import { OPEN, ACCEPTED, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
+import { OPEN, ACTIVE, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
 import PropTypes from 'prop-types';
 import LoadingComponent from '../../common/loading/LoadingComponent';
 import styles from './DonationsComponentStyles.scss';
@@ -88,7 +88,7 @@ class DonationsComponent extends Component {
       return this.getCompletedIcon(row);
     } else if (row.state === EXPIRED || row.state === DECLINED || row.state === FAILED) {
       return this.getRemoveIcon(row);
-    } else if (row.state === OPEN || row.state === ACCEPTED) {
+    } else if (row.state === OPEN || row.state === ACTIVE) {
       return this.getDropdownMenu(row);
     }
 

--- a/web/src/app/profile/MyBountiesComponent/MyBountiesComponent.js
+++ b/web/src/app/profile/MyBountiesComponent/MyBountiesComponent.js
@@ -18,7 +18,7 @@ import BountyDetails from '../BountyDetails/BountyDetails';
 import cx from 'classnames';
 import paginationFactory from 'react-bootstrap-table2-paginator';
 import PropTypes from 'prop-types';
-import { OPEN, ACCEPTED, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
+import { OPEN, ACTIVE, DECLINED, EXPIRED, COMPLETED, FAILED } from '../../BountyState';
 import LoadingComponent from '../../common/loading/LoadingComponent';
 import styles from '../DonationsComponent/DonationsComponentStyles.scss';
 import tableStyles from '../../tableStyles.scss';
@@ -85,7 +85,7 @@ class MyBountiesComponent extends Component {
       return this.getCompletedIcon();
     } else if (row.state === EXPIRED || row.state === DECLINED || row.state === FAILED) {
       return this.getRemoveIcon(row);
-    } else if (row.state === ACCEPTED) {
+    } else if (row.state === ACTIVE) {
       return this.getAcceptedDropdownMenu(row);
     }
 
@@ -331,7 +331,7 @@ class MyBountiesComponent extends Component {
                 >
                   <option value="">All</option>
                   <option value={OPEN}>Open</option>
-                  <option value={ACCEPTED}>Active</option>
+                  <option value={ACTIVE}>Active</option>
                   <option value={COMPLETED}>Completed</option>
                   <option value={DECLINED}>Declined</option>
                   <option value={EXPIRED}>Expired</option>

--- a/web/src/app/profile/duck/operations.js
+++ b/web/src/app/profile/duck/operations.js
@@ -84,7 +84,7 @@ const acceptBounty = (contractId, callback = null) => (dispatch) => {
   const payload = { contractId };
   dispatch(requestAcceptBounty());
 
-  RestClient.PUT('bounties/accept', payload, (response) => {
+  RestClient.PUT('bounties/activate', payload, (response) => {
     dispatch(receiveAcceptBountySuccess());
     if (callback) {
       callback();


### PR DESCRIPTION
Refactors the voting logic to support Active Bounties. Bounties are no longer required to be accepted before voting can take place. The "Active" state is effectively the same as the "Open" state, but we will display it differently on the front end. This means that active bounties can also be expired. 

New timestamp was introduced on the contracts table that records when the contract transitions back to the "open" state.