### PR TITLE
Persist twitch id, business email, fix endpoint, fix warnings

### DIFF
--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractConfig.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractConfig.java
@@ -1,7 +1,6 @@
 package com.nicknathanjustin.streamercontracts.contracts;
 
 import com.nicknathanjustin.streamercontracts.donations.DonationService;
-import com.nicknathanjustin.streamercontracts.security.SecurityService;
 import com.nicknathanjustin.streamercontracts.votes.VoteService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +11,6 @@ public class ContractConfig {
 
     @Autowired private ContractModelRepository contractModelRepository;
     @Autowired private DonationService donationService;
-    @Autowired private SecurityService SecurityService;
     @Autowired private VoteService voteService;
 
     @Bean

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractService.java
@@ -60,20 +60,20 @@ public interface ContractService {
      * @param streamer The user to retrieve contracts by.
      * @param state The state to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param username The username of the user that made the request.
+     * @param requestedByStreamer Boolean that indicates if the request was by the streamer.
      * @return a set of all contracts in the given state for the given user.
      */
-    Page<Contract> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable, String username);
+    Page<Contract> getContractsForStreamerAndState(UserModel streamer, ContractState state, Pageable pageable, boolean requestedByStreamer);
 
     /**
      * Gets all contracts for the given user.
      *
      * @param streamer The user to retrieve contracts by.
      * @param pageable identifies the page number and pagesize to retrieve
-     * @param username The username of the user that made the request.
+     * @param requestedByStreamer Boolean that indicates if the request was by the streamer.
      * @return a set of all contracts for the given user.
      */
-    Page<Contract> getContractsForStreamer(UserModel streamer, Pageable pageable, String username);
+    Page<Contract> getContractsForStreamer(UserModel streamer, Pageable pageable, boolean requestedByStreamer);
 
     /**
      * Gets all contracts in the given state.

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractServiceImpl.java
@@ -23,8 +23,8 @@ public class ContractServiceImpl implements ContractService {
 
     private static final int PAY_PAL_TRANSACTION_TIMEOUT_IN_DAYS = 3;
     private static final int MAX_ACTIVE_CONTRACTS = 1;
-    private static final List PAY_STREAMER_STATES = ImmutableList.of(ContractState.COMPLETED, ContractState.DISPUTED);
-    private static final List PAY_DONOR_STATES = ImmutableList.of(ContractState.DECLINED, ContractState.FAILED, ContractState.EXPIRED);
+    private static final List<ContractState> PAY_STREAMER_STATES = ImmutableList.of(ContractState.COMPLETED, ContractState.DISPUTED);
+    private static final List<ContractState> PAY_DONOR_STATES = ImmutableList.of(ContractState.DECLINED, ContractState.FAILED, ContractState.EXPIRED);
 
 
     @NonNull final ContractModelRepository contractModelRepository;
@@ -93,12 +93,7 @@ public class ContractServiceImpl implements ContractService {
             @NonNull final UserModel user, 
             @NonNull final ContractState state, 
             @NonNull final Pageable pageable, 
-            @Nullable final String username) {
-        boolean requestedByStreamer = false;
-        if (username != null) {
-            requestedByStreamer = username.equals(user.getTwitchUsername());
-        }
-
+            @Nullable final boolean requestedByStreamer) {
         return requestedByStreamer ?
                 contractModelRepository.findAllPrivateContractsForStreamerAndState(user.getTwitchUsername(), state, pageable) :
                 contractModelRepository.findAllPublicContractsForStreamerAndState(user.getTwitchUsername(), state, pageable);
@@ -108,12 +103,7 @@ public class ContractServiceImpl implements ContractService {
     public Page<Contract> getContractsForStreamer(
             @NonNull final UserModel user, 
             @NonNull final Pageable pageable,
-            @Nullable final String username) {
-        boolean requestedByStreamer = false;
-        if (username != null) {
-            requestedByStreamer = username.equals(user.getTwitchUsername());
-        }
-
+            @Nullable final boolean requestedByStreamer) {
         return requestedByStreamer ?
                 contractModelRepository.findAllPrivateContractsForStreamer(user.getTwitchUsername(), pageable) :
                 contractModelRepository.findAllPublicContractsForStreamer(user.getTwitchUsername(), pageable);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiController.java
@@ -81,16 +81,9 @@ public class ContractsApiController {
             @PathVariable final int pageSize,
             @RequestParam("state") @Nullable final ContractState state,
             @RequestParam("username") @Nullable final String username) {
-        UserModel user = null;
-        try {
-            user = userService.getUserModelFromRequest(httpServletRequest);
-        } catch (IllegalStateException e) {
-            // Ignore the IllegalStateException because it is ok if unauthenticated users
-            // list contracts.
-        }
-        
         boolean requestedByStreamer = false;
-        if (username != null && user != null) {
+        if (username != null && !securityService.isAnonymousRequest(httpServletRequest)) {
+            final UserModel user = userService.getUserModelFromRequest(httpServletRequest);
             requestedByStreamer = username.equals(user.getTwitchUsername());
         }
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PrivateContract.java
@@ -4,10 +4,10 @@ import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
 import com.nicknathanjustin.streamercontracts.votes.VoteModel;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
-import java.util.stream.Stream;
-
+@EqualsAndHashCode(callSuper=true)
 @Data
 public class PrivateContract extends Contract {
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PublicContract.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/contracts/dtos/PublicContract.java
@@ -2,8 +2,10 @@ package com.nicknathanjustin.streamercontracts.contracts.dtos;
 
 import com.nicknathanjustin.streamercontracts.contracts.ContractModel;
 
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+@EqualsAndHashCode(callSuper=true)
 @Value
 public class PublicContract extends Contract {
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/emails/EmailApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/emails/EmailApiController.java
@@ -2,7 +2,8 @@ package com.nicknathanjustin.streamercontracts.emails;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,13 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/email")
 @RequiredArgsConstructor
-@Slf4j
 public class EmailApiController {
 
     @NonNull private final EmailService emailService;
 
     @RequestMapping(method = RequestMethod.POST)
-    public ResponseEntity addEmail(@RequestBody @NonNull final CreateEmailRequest createEmailRequest) {
+    public ResponseEntity<HttpStatus> addEmail(@RequestBody @NonNull final CreateEmailRequest createEmailRequest) {
         emailService.createEmail(createEmailRequest.getName(), createEmailRequest.getEmail());
 
         return ResponseEntity.ok().build();

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/reports/ReportsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/reports/ReportsApiController.java
@@ -9,6 +9,8 @@ import com.nicknathanjustin.streamercontracts.users.UserService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +32,7 @@ public class ReportsApiController {
     @NonNull private final UserService userService;
 
     @RequestMapping(method = RequestMethod.POST)
-    public ResponseEntity createReport(@NonNull final HttpServletRequest httpServletRequest,
+    public ResponseEntity<HttpStatus> createReport(@NonNull final HttpServletRequest httpServletRequest,
                                        @RequestBody @NonNull final CreateReportRequest createReportRequest) {
 
         final UserModel reportingUser = securityService.isAnonymousRequest(httpServletRequest) ?

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityService.java
@@ -2,6 +2,10 @@ package com.nicknathanjustin.streamercontracts.security;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+import lombok.NonNull;
+
 public interface SecurityService {
 
     /**
@@ -10,5 +14,14 @@ public interface SecurityService {
      * @param httpServletRequest The request to check.
      * @return true if request comes from an anonymous source. False otherwise.
      */
-    public boolean isAnonymousRequest(HttpServletRequest httpServletRequest);
+    boolean isAnonymousRequest(HttpServletRequest httpServletRequest);
+    
+    /**
+     * Gets a user id from a JWT Token.
+     *
+     * @param jwtToke The JWT token.
+     * @return Returns the userId from the JWT Token.
+     * @throws JWTVerificationException Throws if parsing the JWT token encounters an error.
+     */
+    String getTwitchUserIdFromJwtToken(@NonNull final String jwtToken) throws JWTVerificationException;
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
@@ -46,15 +46,7 @@ public class SecurityServiceImpl implements SecurityService {
         final String jwtToken = httpServletRequest.getHeader(jwtHeader);
         final Principal principal = httpServletRequest.getUserPrincipal();
         
-        if (jwtToken != null) {
-            try {
-                getTwitchUserIdFromJwtToken(jwtToken);
-            } catch (IllegalStateException e) {
-                return true;
-            }
-        }
-
-        final boolean isUserRecognized = (jwtToken != null || principal instanceof OAuth2Authentication);
+        final boolean isUserRecognized = ((jwtToken != null && getTwitchUserIdFromJwtToken(jwtToken) != null) || principal instanceof OAuth2Authentication);
         if (isUserRecognized) {
             return isRecognizedUserBlocked(httpServletRequest);
         }
@@ -92,7 +84,7 @@ public class SecurityServiceImpl implements SecurityService {
         final Jws<Claims> jws = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
         final Claims claims = jws.getBody();
         if (!claims.containsKey(USER_ID_CLAIM_KEY)) {
-            throw new IllegalStateException("Claim: " + USER_ID_CLAIM_KEY + " does not exist for decoded jwtToken: " + jws);
+            return null;
         }
 
         return claims.get(USER_ID_CLAIM_KEY, String.class);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
@@ -1,23 +1,36 @@
 package com.nicknathanjustin.streamercontracts.security;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.nicknathanjustin.streamercontracts.users.UserService;
 import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
+import javax.crypto.SecretKey;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.Base64;
 
 @RequiredArgsConstructor
 public class SecurityServiceImpl implements SecurityService {
+
+    private static final String USER_ID_CLAIM_KEY = "user_id";
 
     @NonNull private final UserService userService;
 
     @Value("${twitch.extension.jwtHeader}")
     private String jwtHeader;
+    
+    @Value("${twitch.extension.secret}")
+    private String jwtSigningSecret;
 
     @Value("${twitch.whiteListedAccounts}")
     private String[] whiteListedAccounts;
@@ -32,11 +45,20 @@ public class SecurityServiceImpl implements SecurityService {
     public boolean isAnonymousRequest(@NonNull final HttpServletRequest httpServletRequest) {
         final String jwtToken = httpServletRequest.getHeader(jwtHeader);
         final Principal principal = httpServletRequest.getUserPrincipal();
-        final boolean isUserRecognized = (jwtToken != null || principal instanceof OAuth2Authentication);
+        
+        if (jwtToken != null) {
+            try {
+                getTwitchUserIdFromJwtToken(jwtToken);
+            } catch (IllegalStateException e) {
+                return true;
+            }
+        }
 
+        final boolean isUserRecognized = (jwtToken != null || principal instanceof OAuth2Authentication);
         if (isUserRecognized) {
             return isRecognizedUserBlocked(httpServletRequest);
         }
+
         return true;
     }
 
@@ -60,5 +82,19 @@ public class SecurityServiceImpl implements SecurityService {
 
     private boolean isUserBlackListed(@NonNull final TwitchUser twitchUser) {
         return Arrays.asList(blackListedAccounts).contains(twitchUser.getDisplayName());
+    }
+    
+    @Override
+    public String getTwitchUserIdFromJwtToken(@NonNull final String jwtToken) throws JWTVerificationException {
+        final String token = jwtToken.split(" ")[1];
+        final byte[] decodedSecret = Base64.getDecoder().decode(jwtSigningSecret);
+        final SecretKey key = Keys.hmacShaKeyFor(decodedSecret);
+        final Jws<Claims> jws = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+        final Claims claims = jws.getBody();
+        if (!claims.containsKey(USER_ID_CLAIM_KEY)) {
+            throw new IllegalStateException("Claim: " + USER_ID_CLAIM_KEY + " does not exist for decoded jwtToken: " + jws);
+        }
+
+        return claims.get(USER_ID_CLAIM_KEY, String.class);
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/security/SecurityServiceImpl.java
@@ -4,7 +4,6 @@ import com.nicknathanjustin.streamercontracts.users.UserService;
 import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
@@ -13,7 +12,6 @@ import java.security.Principal;
 import java.util.Arrays;
 
 @RequiredArgsConstructor
-@Slf4j
 public class SecurityServiceImpl implements SecurityService {
 
     @NonNull private final UserService userService;

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsApiController.java
@@ -6,7 +6,6 @@ import com.nicknathanjustin.streamercontracts.users.UserModel;
 import com.nicknathanjustin.streamercontracts.users.UserService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +19,6 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/userSettings")
 @RequiredArgsConstructor
-@Slf4j
 public class UserSettingsApiController {
 
     @NonNull private final SecurityService SecurityService;
@@ -28,21 +26,21 @@ public class UserSettingsApiController {
     @NonNull private final UserSettingsService userSettingsService;
 
     @RequestMapping(method = RequestMethod.POST)
-    public ResponseEntity updateUserSettings(@NonNull final HttpServletRequest httpServletRequest,
+    public ResponseEntity<HttpStatus> updateUserSettings(@NonNull final HttpServletRequest httpServletRequest,
                                              @RequestBody @NonNull final UpdateUserSettingsRequest updateUserSettingsRequest) {
         if (SecurityService.isAnonymousRequest(httpServletRequest)) {
-            return new ResponseEntity(HttpStatus.FORBIDDEN);
+            return new ResponseEntity<HttpStatus>(HttpStatus.FORBIDDEN);
         }
 
         final UserModel userModel = userService.getUserModelFromRequest(httpServletRequest);
         userSettingsService.updateUserSettings(userModel, updateUserSettingsRequest);
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<HttpStatus>(HttpStatus.OK);
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity getUserSettings(@NonNull final HttpServletRequest httpServletRequest) {
+    public ResponseEntity<?> getUserSettings(@NonNull final HttpServletRequest httpServletRequest) {
         if (SecurityService.isAnonymousRequest(httpServletRequest)) {
-            return new ResponseEntity(HttpStatus.FORBIDDEN);
+            return new ResponseEntity<HttpStatus>(HttpStatus.FORBIDDEN);
         }
 
         final UserModel userModel = userService.getUserModelFromRequest(httpServletRequest);
@@ -54,6 +52,6 @@ public class UserSettingsApiController {
             return ResponseEntity.ok(userSettingsDto);
         }
 
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<HttpStatus>(HttpStatus.OK);
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsDto.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsDto.java
@@ -5,9 +5,13 @@ import lombok.Value;
 
 @Value
 public class UserSettingsDto {
+
     private final String paypalEmail;
+    
+    private final Boolean isBusinessEmail;
 
     public UserSettingsDto(@NonNull UserSettingsModel userSettingsModel) {
         this.paypalEmail = userSettingsModel.getPaypalEmail();
+        this.isBusinessEmail = userSettingsModel.getIsBusinessEmail();
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsModel.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsModel.java
@@ -38,4 +38,6 @@ public class UserSettingsModel {
     private Timestamp createdAt;
 
     private Timestamp updatedAt;
+    
+    private Boolean isBusinessEmail;
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/UserSettingsServiceImpl.java
@@ -17,7 +17,6 @@ public class UserSettingsServiceImpl implements UserSettingsService {
     public UserSettingsModel updateUserSettings(@NonNull final UserModel userModel,
                                                 @NonNull final UpdateUserSettingsRequest updateUserSettingsRequest) {
         final Timestamp now = new Timestamp(System.currentTimeMillis());
-        final String paypalEmail = updateUserSettingsRequest.getPaypalEmail();
         final Optional<UserSettingsModel> optionalUserSettingsModel = userSettingsModelRepository.findByUserId(userModel.getId());
         final UserSettingsModel userSettingsModel = optionalUserSettingsModel.orElse(
                 UserSettingsModel.builder()
@@ -26,8 +25,11 @@ public class UserSettingsServiceImpl implements UserSettingsService {
                 .build()
         );
 
+        final String paypalEmail = updateUserSettingsRequest.getPaypalEmail();
+        final Boolean isBusinessEmail = updateUserSettingsRequest.getIsBusinessEmail();
         userSettingsModel.setPaypalEmail(paypalEmail);
         userSettingsModel.setUpdatedAt(now);
+        userSettingsModel.setIsBusinessEmail(isBusinessEmail);
 
         return userSettingsModelRepository.save(userSettingsModel);
     }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/requests/UpdateUserSettingsRequest.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/settings/requests/UpdateUserSettingsRequest.java
@@ -1,5 +1,7 @@
 package com.nicknathanjustin.streamercontracts.settings.requests;
 
+import org.springframework.lang.Nullable;
+
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -8,4 +10,5 @@ import lombok.Value;
 @Builder
 public class UpdateUserSettingsRequest {
     @NonNull private String paypalEmail;
+    @Nullable private Boolean isBusinessEmail;
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchApiController.java
@@ -2,7 +2,6 @@ package com.nicknathanjustin.streamercontracts.twitch;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,18 +11,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/twitch")
 @RequiredArgsConstructor
-@Slf4j
 public class TwitchApiController {
 
     @NonNull private final TwitchService twitchService;
 
     @RequestMapping(path = "/topGames", method = RequestMethod.GET)
-    public ResponseEntity getTopGames() {
+    public ResponseEntity<?> getTopGames() {
         return ResponseEntity.ok(twitchService.getTopGames());
     }
 
     @RequestMapping(path = "/game/{gameName}", method = RequestMethod.GET)
-    public ResponseEntity getGame(@PathVariable("gameName") @NonNull final String gameName) {
+    public ResponseEntity<?> getGame(@PathVariable("gameName") @NonNull final String gameName) {
         return ResponseEntity.ok(twitchService.getGame(gameName));
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchService.java
@@ -5,7 +5,6 @@ import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public interface TwitchService {
 
@@ -30,7 +29,7 @@ public interface TwitchService {
      * @param twitchUsername The username of the twitch user
      * @return An Optional<TwitchUser> for the user
      */
-    Optional<TwitchUser> getTwitchUserFromUsername(String twitchUsername);
+    TwitchUser getTwitchUserFromUsername(String twitchUsername);
 
     /**
      * Gets the TwitchUser object from Twitch API
@@ -38,5 +37,5 @@ public interface TwitchService {
      * @param twitchUserId The id of the twitch user
      * @return An Optional<TwitchUser> for the user
      */
-    Optional<TwitchUser> getTwitchUserFromTwitchUserId(String twitchUserId);
+    TwitchUser getTwitchUserFromTwitchUserId(String twitchUserId);
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/twitch/TwitchServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 public class TwitchServiceImpl implements TwitchService {
@@ -59,14 +58,14 @@ public class TwitchServiceImpl implements TwitchService {
     }
 
     @Override
-    public Optional<TwitchUser> getTwitchUserFromUsername(@NonNull final String twitchUsername) {
+    public TwitchUser getTwitchUserFromUsername(@NonNull final String twitchUsername) {
         final ResponseEntity<Map> response = queryTwitch(userInfoUri + "?login=" + twitchUsername);
         final Map<String, List<Map<String, Object>>> details = response.getBody();
         return TwitchUser.createTwitchUser(details);
     }
 
     @Override
-    public Optional<TwitchUser> getTwitchUserFromTwitchUserId(@NonNull final String twitchUserId) {
+    public TwitchUser getTwitchUserFromTwitchUserId(@NonNull final String twitchUserId) {
         final ResponseEntity<Map> response = queryTwitch(userInfoUri + "?id=" + twitchUserId);
         final Map<String, List<Map<String, Object>>> details = response.getBody();
         return TwitchUser.createTwitchUser(details);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserConfig.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserConfig.java
@@ -1,6 +1,7 @@
 package com.nicknathanjustin.streamercontracts.users;
 
 import com.nicknathanjustin.streamercontracts.twitch.TwitchService;
+import com.nicknathanjustin.streamercontracts.security.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,9 +11,10 @@ public class UserConfig {
 
     @Autowired private TwitchService twitchService;
     @Autowired private UserModelRepository userModelRepository;
+    @Autowired private SecurityService securityService;
 
     @Bean
     public UserService userService() {
-        return new UserServiceImpl(twitchService, userModelRepository);
+        return new UserServiceImpl(twitchService, userModelRepository, securityService);
     }
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserModel.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserModel.java
@@ -29,6 +29,8 @@ public class UserModel {
     private UUID id;
 
     private String twitchUsername;
+    
+    private String twitchId;
 
     private Timestamp createdAt;
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserService.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserService.java
@@ -12,9 +12,10 @@ public interface UserService {
      * Creates the user in the database given the twitch username.
      *
      * @param  twitchUsername The username of the twitch user.
+     * @param  twitchId The id of the twitch user.
      * @return An object modeling the user.
      */
-    UserModel createUser(String twitchUsername);
+    UserModel createUser(String twitchUsername, String twitchId);
 
     /**
      * Gets a user from the database given the twitch username.
@@ -44,16 +45,14 @@ public interface UserService {
      *
      * @param httpServletRequest HttpRequest to get a user from.
      * @return UserModel associated with the provided HttpRequest.
-     * @throws IllegalArgumentException thrown when no user is associated with the supplied request.
      */
-    UserModel getUserModelFromRequest(HttpServletRequest httpServletRequest) throws IllegalArgumentException;
+    UserModel getUserModelFromRequest(HttpServletRequest httpServletRequest);
 
     /**
      * Returns a TwitchUser from a valid HttpRequest Object.
      *
      * @param httpServletRequest the HttpRequest to get a user from.
      * @return TwitchUser associated with the provided HttpRequest.
-     * @throws IllegalArgumentException thrown when no user is associated with the supplied request.
      */
     TwitchUser getTwitchUserFromRequest(HttpServletRequest httpServletRequest);
 }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserServiceImpl.java
@@ -94,6 +94,10 @@ public class UserServiceImpl implements UserService {
 
     private TwitchUser getTwitchUserFromJwtToken(@NonNull final String jwtToken) {
         final String twitchUserId = securityService.getTwitchUserIdFromJwtToken(jwtToken);
+        if (twitchUserId == null) {
+            throw new IllegalStateException("unable to parse twitch user id from JWT token.");
+        }
+
         final TwitchUser twitchUser = twitchService.getTwitchUserFromTwitchUserId(twitchUserId);
         if (twitchUser == null) {
             throw new IllegalStateException("unable to retrieve " + TwitchUser.class.getName() + " with twitchUserId: " + twitchUserId);

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserServiceImpl.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UserServiceImpl.java
@@ -9,7 +9,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 
 @RequiredArgsConstructor
-@Slf4j
 public class UserServiceImpl implements UserService {
 
     private static final String USER_ID_CLAIM_KEY = "user_id";
@@ -41,10 +39,11 @@ public class UserServiceImpl implements UserService {
     private String jwtHeader;
 
     @Override
-    public UserModel createUser(@NonNull final String twitchUsername) {
+    public UserModel createUser(@NonNull final String twitchUsername, @NonNull final String twitchId) {
         final Timestamp creationTimestamp = new Timestamp(System.currentTimeMillis());
         return userModelRepository.save(UserModel.builder()
                 .twitchUsername(twitchUsername)
+                .twitchId(twitchId)
                 .totalLogins(1)
                 .createdAt(creationTimestamp)
                 .lastLogin(creationTimestamp)
@@ -71,11 +70,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserModel getUserModelFromRequest(@NonNull final HttpServletRequest httpServletRequest) throws IllegalArgumentException {
+    public UserModel getUserModelFromRequest(@NonNull final HttpServletRequest httpServletRequest) {
         final TwitchUser twitchUser = getTwitchUserFromRequest(httpServletRequest);
         final UserModel userModel = getUser(twitchUser.getDisplayName()).orElse(null);
         if (userModel == null) {
-            throw new IllegalArgumentException("unable to retrieve " + UserModel.class.getName() + " from authentication object: " + httpServletRequest);
+            throw new IllegalStateException("unable to retrieve " + UserModel.class.getName() + " from authentication object: " + httpServletRequest);
         }
         return userModel;
     }
@@ -89,25 +88,25 @@ public class UserServiceImpl implements UserService {
         } else if (principal instanceof OAuth2Authentication){
             return getTwitchUserFromOAuth((OAuth2Authentication) principal);
         } else {
-            throw new IllegalArgumentException("No jwtToken or OAuth2Authentication associated with httpServletRequest: " + httpServletRequest);
+            throw new IllegalStateException("No jwtToken or OAuth2Authentication associated with httpServletRequest: " + httpServletRequest);
         }
     }
 
     private TwitchUser getTwitchUserFromOAuth(@NonNull final OAuth2Authentication oAuth2Authentication) {
         final Authentication userAuth = oAuth2Authentication.getUserAuthentication();
         final Map<String, List<Map<String, Object>>> authDetails = (Map<String, List<Map<String, Object>>>) userAuth.getDetails();
-        final TwitchUser twitchUser = TwitchUser.createTwitchUser(authDetails).orElse(null);
+        final TwitchUser twitchUser = TwitchUser.createTwitchUser(authDetails);
         if (twitchUser == null) {
-            throw new IllegalArgumentException("unable to retrieve " + TwitchUser.class.getName() + " from oAuth2Authentication: " + oAuth2Authentication);
+            throw new IllegalStateException("unable to retrieve " + TwitchUser.class.getName() + " from oAuth2Authentication: " + oAuth2Authentication);
         }
         return twitchUser;
     }
 
     private TwitchUser getTwitchUserFromJwtToken(@NonNull final String jwtToken) {
         final String twitchUserId = getTwitchUserIdFromJwtToken(jwtToken);
-        final TwitchUser twitchUser = twitchService.getTwitchUserFromTwitchUserId(twitchUserId).orElse(null);
+        final TwitchUser twitchUser = twitchService.getTwitchUserFromTwitchUserId(twitchUserId);
         if (twitchUser == null) {
-            throw new IllegalArgumentException("unable to retrieve " + TwitchUser.class.getName() + " with twitchUserId: " + twitchUserId);
+            throw new IllegalStateException("unable to retrieve " + TwitchUser.class.getName() + " with twitchUserId: " + twitchUserId);
         }
         return twitchUser;
     }
@@ -119,7 +118,7 @@ public class UserServiceImpl implements UserService {
         final Jws<Claims> jws = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
         final Claims claims = jws.getBody();
         if (!claims.containsKey(USER_ID_CLAIM_KEY)) {
-            throw new IllegalArgumentException("Claim: " + USER_ID_CLAIM_KEY + " does not exist for decoded jwtToken: " + jws);
+            throw new IllegalStateException("Claim: " + USER_ID_CLAIM_KEY + " does not exist for decoded jwtToken: " + jws);
         }
         return claims.get(USER_ID_CLAIM_KEY, String.class);
     }

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UsersApiController.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/UsersApiController.java
@@ -11,6 +11,8 @@ import com.nicknathanjustin.streamercontracts.users.dtos.PublicUser;
 import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -36,9 +38,9 @@ public class UsersApiController {
     @NonNull private final UserSettingsService userSettingsService;
 
     @RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity privateUser(@NonNull final HttpServletRequest httpServletRequest) {
+    public ResponseEntity<?> privateUser(@NonNull final HttpServletRequest httpServletRequest) {
         if (SecurityService.isAnonymousRequest(httpServletRequest)) {
-            return new ResponseEntity(HttpStatus.FORBIDDEN);
+            return new ResponseEntity<HttpStatus>(HttpStatus.FORBIDDEN);
         }
 
         final UserModel userModel = userService.getUserModelFromRequest(httpServletRequest);
@@ -67,11 +69,10 @@ public class UsersApiController {
     }
 
     @RequestMapping(path = "/{twitchUsername}", method = RequestMethod.GET)
-    public ResponseEntity publicUser(@PathVariable("twitchUsername") @NonNull final String twitchUsername) {
-        final Optional<TwitchUser> optionalTwitchUser = twitchService.getTwitchUserFromUsername(twitchUsername);
+    public ResponseEntity<?> publicUser(@PathVariable("twitchUsername") @NonNull final String twitchUsername) {
+        final TwitchUser twitchUser = twitchService.getTwitchUserFromUsername(twitchUsername);
         final Optional<UserModel> optionalUserModel = userService.getUser(twitchUsername);
         final UserModel userModel = optionalUserModel.orElse(null);
-        final TwitchUser twitchUser = optionalTwitchUser.orElse(null);
 
         if (twitchUser != null && userModel != null) {
             final UserSettingsModel userSettingsModel = userSettingsService.getUserSettings(userModel).orElse(null);
@@ -79,11 +80,11 @@ public class UsersApiController {
             return ResponseEntity.ok(publicUser);
         }
 
-        return new ResponseEntity(HttpStatus.NOT_FOUND);
+        return new ResponseEntity<HttpStatus>(HttpStatus.NOT_FOUND);
     }
 
     @RequestMapping(path = "list/{page}/{pageSize}", method = RequestMethod.GET)
-    public ResponseEntity listUsers(
+    public ResponseEntity<Page<UserModel>> listUsers(
             @NonNull final HttpServletRequest httpServletRequest,
             @PathVariable final int page,
             @PathVariable final int pageSize) {

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/PrivateUser.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/PrivateUser.java
@@ -4,11 +4,13 @@ import com.google.common.hash.Hashing;
 import com.nicknathanjustin.streamercontracts.users.UserModel;
 import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 
+@EqualsAndHashCode(callSuper=true)
 @Data
 public class PrivateUser extends User {
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/PublicUser.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/PublicUser.java
@@ -2,10 +2,13 @@ package com.nicknathanjustin.streamercontracts.users.dtos;
 
 import com.nicknathanjustin.streamercontracts.settings.UserSettingsModel;
 import com.nicknathanjustin.streamercontracts.users.externalusers.TwitchUser;
+
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 import org.springframework.lang.Nullable;
 
+@EqualsAndHashCode(callSuper=true)
 @Value
 public class PublicUser extends User {
 

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/User.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/dtos/User.java
@@ -7,6 +7,8 @@ import lombok.NonNull;
 @Data
 public abstract class User {
 
+    private final String externalId;
+    
     private final String displayName;
 
     private final String type;
@@ -20,6 +22,7 @@ public abstract class User {
     private final int viewCount;
 
     public User(@NonNull final ExternalUser externalUser) {
+        this.externalId = externalUser.getExternalId();
         this.displayName = externalUser.getDisplayName();
         this.type = externalUser.getType();
         this.broadcasterType = externalUser.getBroadcasterType();

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/externalusers/ExternalUser.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/externalusers/ExternalUser.java
@@ -5,6 +5,8 @@ import lombok.Data;
 @Data
 public abstract class ExternalUser {
 
+    protected String externalId;
+    
     protected String login;
 
     protected String displayName;

--- a/api/src/main/java/com/nicknathanjustin/streamercontracts/users/externalusers/TwitchUser.java
+++ b/api/src/main/java/com/nicknathanjustin/streamercontracts/users/externalusers/TwitchUser.java
@@ -5,16 +5,16 @@ import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class TwitchUser extends ExternalUser {
 
-    public static Optional<TwitchUser> createTwitchUser(@NonNull final Map<String, List<Map<String, Object>>> details) {
+    public static TwitchUser createTwitchUser(@NonNull final Map<String, List<Map<String, Object>>> details) {
         TwitchUser twitchUser = null;
         final List<Map<String, Object>> data = details.get("data");
         if (!CollectionUtils.isEmpty(data)) {
             final Map<String, Object> properties = data.get(0);
             twitchUser = new TwitchUser(
+                    (String) properties.get("id"),
                     (String) properties.get("login"),
                     (String) properties.get("display_name"),
                     (String) properties.get("type"),
@@ -26,11 +26,11 @@ public class TwitchUser extends ExternalUser {
             );
         }
 
-        return Optional.ofNullable(twitchUser);
+        return twitchUser;
     }
 
-
     public TwitchUser(
+            @NonNull final String externalId,
             @NonNull final String login,
             @NonNull final String displayName,
             @NonNull final String type,
@@ -39,6 +39,7 @@ public class TwitchUser extends ExternalUser {
             @NonNull final String profileImageUrl,
             @NonNull final String offlineImageUrl,
             final int viewCount) {
+        this.externalId = externalId;
         this.login = login;
         this.displayName = displayName;
         this.type = type;

--- a/api/src/test/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiControllerTest.java
+++ b/api/src/test/java/com/nicknathanjustin/streamercontracts/contracts/ContractsApiControllerTest.java
@@ -45,7 +45,7 @@ public class ContractsApiControllerTest {
 
     @Test(expected = NullPointerException.class)
     public void voteOnContract_nullRequest_throwsException() {
-        final ResponseEntity response = contractsApiController.voteOnContract(null, CONTRACT_VOTE_REQUEST);
+        contractsApiController.voteOnContract(null, CONTRACT_VOTE_REQUEST);
     }
 
     @Test(expected = NullPointerException.class)
@@ -55,14 +55,14 @@ public class ContractsApiControllerTest {
 
     @Test(expected = NullPointerException.class)
     public void voteOnContract_requestIsUnauthorized_returnsForbidden() {
-        final ResponseEntity response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, null);
+        final ResponseEntity<HttpStatus> response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, null);
 
         Assert.assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
     }
 
     @Test
     public void voteOnContract_noContractForSuppliedId_returnsNotFound() {
-        final ResponseEntity response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
+        final ResponseEntity<HttpStatus> response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
 
         Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
@@ -77,7 +77,7 @@ public class ContractsApiControllerTest {
         when(mockUserService.getUserModelFromRequest(MOCK_HTTP_SERVLET_REQUEST)).thenReturn(userModel);
         when(mockContractService.getContract(CONTRACT_ID)).thenReturn(Optional.of(contractModel));
 
-        final ResponseEntity response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
+        final ResponseEntity<HttpStatus> response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
 
         verify(mockVoteService).recordVote(userModel, contractModel, FLAG_COMPLETED);
         Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -99,7 +99,7 @@ public class ContractsApiControllerTest {
         when(mockVoteService.isVotingComplete(proposerVote, streamerVote, contractModel)).thenReturn(true);
         when(mockVoteService.getVoteOutcome(proposerVote, streamerVote, contractModel)).thenReturn(voteOutcome);
 
-        final ResponseEntity response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
+        final ResponseEntity<HttpStatus> response = contractsApiController.voteOnContract(MOCK_HTTP_SERVLET_REQUEST, CONTRACT_VOTE_REQUEST);
 
         verify(mockVoteService).recordVote(userModel, contractModel, FLAG_COMPLETED);
         verify(mockContractService).setContractState(contractModel, voteOutcome);

--- a/api/src/test/java/com/nicknathanjustin/streamercontracts/users/UserServiceImplTest.java
+++ b/api/src/test/java/com/nicknathanjustin/streamercontracts/users/UserServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 public class UserServiceImplTest {
 
     private static final String TWITCH_USER_NAME = "twitchUserName";
+    private static final String TWITCH_ID = "123456";
     private static final int TOTAL_LOGINS = 1;
     private static final Timestamp CREATED_AT = new Timestamp(System.currentTimeMillis());
     private static final Timestamp LAST_LOGIN = new Timestamp(System.currentTimeMillis());
@@ -41,8 +42,13 @@ public class UserServiceImplTest {
 
 
     @Test(expected = NullPointerException.class)
-    public void createUser_nullInput_throwsException() {
-        userService.createUser(null);
+    public void createUser_nullTwitchUsername_throwsException() {
+        userService.createUser(null, TWITCH_ID);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void createUser_nullTwitchId_throwsException() {
+        userService.createUser(TWITCH_USER_NAME, null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -59,7 +65,7 @@ public class UserServiceImplTest {
     public void createUser_validInput_createsUser() {
         final ArgumentCaptor<UserModel> userModelArgumentCaptor = ArgumentCaptor.forClass(UserModel.class);
 
-        userService.createUser(TWITCH_USER_NAME);
+        userService.createUser(TWITCH_USER_NAME, TWITCH_ID);
 
         verify(mockUserModelRepository).save(userModelArgumentCaptor.capture());
         final UserModel userModel = userModelArgumentCaptor.getValue();

--- a/dev_ops/sql/Tables/CreateUserSettings.sql
+++ b/dev_ops/sql/Tables/CreateUserSettings.sql
@@ -3,5 +3,6 @@ CREATE TABLE user_settings (
     user_id UUID REFERENCES users (id) NOT NULL,
     paypal_email VARCHAR(128) UNIQUE,
     created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL,
+	is_business_email BOOLEAN NULL
 );

--- a/dev_ops/sql/Tables/CreateUserSettings.sql
+++ b/dev_ops/sql/Tables/CreateUserSettings.sql
@@ -4,5 +4,5 @@ CREATE TABLE user_settings (
     paypal_email VARCHAR(128) UNIQUE,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
-	is_business_email BOOLEAN NULL
+    is_business_email BOOLEAN NULL
 );

--- a/dev_ops/sql/Tables/CreateUsers.sql
+++ b/dev_ops/sql/Tables/CreateUsers.sql
@@ -1,6 +1,7 @@
 CREATE TABLE users (
     id UUID PRIMARY KEY,
 	twitch_username VARCHAR(128) UNIQUE,
+	twitch_id VARCHAR(128) UNIQUE,
 	created_at TIMESTAMP NOT NULL,
 	last_login TIMESTAMP NOT NULL,
 	total_logins INT CONSTRAINT nonnegative_logins CHECK (total_logins >= 0) NOT NULL,


### PR DESCRIPTION
This PR makes persists the twitch id for each user and returns it to the front end as part of the user DTO. It also persists a boolean indicating if the streamer's business email is setup correctly.

This PR also fixes the listContracts endpoint, since recently it was changed which caused some problems when requesting contracts for unauthenticated users. It also cleans up a bunch of warnings that eclipse is generating.